### PR TITLE
Remove unused SceneDelegate keys

### DIFF
--- a/Sum/Info.plist
+++ b/Sum/Info.plist
@@ -38,8 +38,6 @@
 				<dict>
 					<key>UISceneConfigurationName</key>
 					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
## Summary
- clean up Info.plist by dropping stale `UISceneDelegateClassName` entries

## Testing
- `git status --short`