### PR TITLE
Add UIKit import to DigitClassifierServiceTests

### DIFF
--- a/SumTests/DigitClassifierServiceTests.swift
+++ b/SumTests/DigitClassifierServiceTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 @testable import Sum
 
 final class DigitClassifierServiceTests: XCTestCase {


### PR DESCRIPTION
## Summary
- ensure `DigitClassifierServiceTests` can access UIKit types by importing UIKit

## Testing
- `swiftc -parse SumTests/DigitClassifierServiceTests.swift`