### PR TITLE
Update live OCR highlights

### DIFF
--- a/Sum/ContentView.swift
+++ b/Sum/ContentView.swift
@@ -243,6 +243,15 @@ struct ContentView: View {
                             print("LiveScanner view appeared")
                         }
                         .overlay(
+                            LiveHighlightOverlay(
+                                rects: liveHighlights,
+                                rectConfs: liveConfs,
+                                onTap: { idx in
+                                    liveScannerCoord?.requestFix(at: idx)
+                                }
+                            )
+                        )
+                        .overlay(
                             LiveOverlayView(numbers: scanVM.liveNumbers)
                                 .allowsHitTesting(false)
                         )

--- a/Sum/UI/LiveScannerView.swift
+++ b/Sum/UI/LiveScannerView.swift
@@ -32,7 +32,8 @@ struct LiveScannerView: UIViewControllerRepresentable {
             recognizesMultipleItems: true,
             isHighFrameRateTrackingEnabled: false,
             isGuidanceEnabled: false,
-            isHighlightingEnabled: true
+            // Disable built-in highlights so we can draw our own
+            isHighlightingEnabled: false
         )
 
         context.coordinator.scannerVC = scanner


### PR DESCRIPTION
## Summary
- disable built in highlighting by DataScannerViewController
- draw custom highlight boxes for recognized numbers

## Testing
- `xcodebuild test -scheme Sum -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*