### PR TITLE
Implement navigation state persistence

### DIFF
--- a/Sum/ContentView.swift
+++ b/Sum/ContentView.swift
@@ -89,11 +89,11 @@ struct ContentView: View {
             HStack {
                 // Leading items
                 HStack(spacing: 16) {
-                    Button { navVM.isShowingScanner = true } label: {
+                    Button { navVM.show(.scanner) } label: {
                         Label("Scan", systemImage: "camera.viewfinder")
                             .symbolEffect(.bounce, value: navVM.isShowingScanner)
                     }
-                    Button { navVM.isShowingPhotoPicker = true } label: {
+                    Button { navVM.show(.picker) } label: {
                         Label("Photo", systemImage: "photo.on.rectangle")
                             .symbolEffect(.bounce, value: navVM.isShowingPhotoPicker)
                     }
@@ -106,7 +106,7 @@ struct ContentView: View {
                     if #available(iOS 17.0, *) {
                         Button {
                             scanVM.startLiveScan()
-                            navVM.isShowingLiveScanner = true
+                            navVM.show(.live)
                         } label: {
                             Label("Live", systemImage: "eye")
                                 .symbolEffect(.bounce, value: navVM.isShowingLiveScanner)
@@ -211,8 +211,8 @@ struct ContentView: View {
                 NavigationStack {
                     PhotoPickerView { img in
                         scanVM.handlePickedImage(img)
-                        navVM.isShowingPhotoPicker = false
-                        navVM.isShowingCropper     = true
+                        navVM.hideCurrent()
+                        navVM.show(.cropper)
                     }
                     .navigationTitle("Choose a Photo")
                     .navigationBarTitleDisplayMode(.inline)
@@ -258,8 +258,8 @@ struct ContentView: View {
                         ImageCropperView(image: uiImage) { cropImage, obs, fixes in
                             scanVM.handleCroppedNumbers(obs.map(\.value), fixes: fixes)
                             scanVM.receiveCroppedResult(image: cropImage, observations: obs)
-                            navVM.isShowingCropper = false
-                            navVM.isShowingResult  = true
+                            navVM.hideCurrent()
+                            navVM.show(.result)
                         }
                         .navigationBarTitleDisplayMode(.inline)
                     }
@@ -270,7 +270,7 @@ struct ContentView: View {
                 if let img = scanVM.croppedImage,
                    let obs = scanVM.croppedObservations {
                     CroppedResultView(image: img, observations: obs)
-                        .onTapGesture { navVM.isShowingResult = false }
+                        .onTapGesture { navVM.hideCurrent() }
                 }
             }
             // MARK: - Fix-digit sheet
@@ -298,6 +298,7 @@ struct ContentView: View {
                             await requestCameraPermission()
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                                 isReady = true
+                                navVM.restoreLastState()
                             }
                         }
                     }

--- a/Sum/ViewModels/NavigationViewModel.swift
+++ b/Sum/ViewModels/NavigationViewModel.swift
@@ -3,60 +3,73 @@ import SwiftUI
 /// Holds every sheet / full-screen-cover flag and manages navigation state.
 @MainActor
 final class NavigationViewModel: ObservableObject {
+    enum Screen: String {
+        case scanner, live, picker, cropper, result
+    }
+
     @Published var isShowingScanner      = false
     @Published var isShowingLiveScanner  = false
     @Published var isShowingPhotoPicker  = false
     @Published var isShowingCropper      = false
     @Published var isShowingResult       = false
-    
+
     @AppStorage("lastView") private var lastView: String?
-    
-    // Navigation stack history
-    private var navigationHistory: [String] = []
+
+    private var navigationHistory: [Screen] = []
     private let maxHistoryItems = 10
-    
-    func pushView(_ identifier: String) {
-        navigationHistory.append(identifier)
+
+    // MARK: - Presentation Helpers
+    func show(_ screen: Screen) {
+        switch screen {
+        case .scanner: isShowingScanner = true
+        case .live:    isShowingLiveScanner = true
+        case .picker:  isShowingPhotoPicker = true
+        case .cropper: isShowingCropper = true
+        case .result:  isShowingResult = true
+        }
+        push(screen)
+    }
+
+    func hideCurrent() {
+        guard let last = navigationHistory.popLast() else { return }
+        lastView = navigationHistory.last?.rawValue
+        switch last {
+        case .scanner: isShowingScanner = false
+        case .live:    isShowingLiveScanner = false
+        case .picker:  isShowingPhotoPicker = false
+        case .cropper: isShowingCropper = false
+        case .result:  isShowingResult = false
+        }
+    }
+
+    /// Dismiss all currently presented screens.
+    func dismissAll() {
+        withAnimation { popToRoot() }
+    }
+
+    /// Restore the last viewed screen on launch.
+    func restoreLastState() {
+        guard let raw = lastView, let screen = Screen(rawValue: raw) else { return }
+        show(screen)
+    }
+
+    // MARK: - Private Helpers
+    private func push(_ screen: Screen) {
+        navigationHistory.append(screen)
         if navigationHistory.count > maxHistoryItems {
             navigationHistory.removeFirst()
         }
-        lastView = identifier
+        lastView = screen.rawValue
     }
-    
-    func popToRoot() {
+
+    private func popToRoot() {
         isShowingScanner = false
         isShowingLiveScanner = false
         isShowingPhotoPicker = false
         isShowingCropper = false
         isShowingResult = false
         navigationHistory.removeAll()
-    }
-    
-    func restoreLastState() {
-        guard let last = lastView else { return }
-        switch last {
-        case "scanner": isShowingScanner = true
-        case "live": isShowingLiveScanner = true
-        case "picker": isShowingPhotoPicker = true
-        case "cropper": isShowingCropper = true
-        case "result": isShowingResult = true
-        default: break
-        }
+        lastView = nil
     }
 }
 
-// MARK: - Navigation State
-extension NavigationViewModel {
-    func dismissAll() {
-        withAnimation {
-            popToRoot()
-        }
-    }
-    
-    func handleMemoryWarning() {
-        // If we're showing multiple screens, go back to root
-        if navigationHistory.count > 1 {
-            dismissAll()
-        }
-    }
-}


### PR DESCRIPTION
## Summary
- add `Screen` enum and history storage in `NavigationViewModel`
- track presented views and restore the last one on launch
- update `ContentView` to use new navigation helpers

## Testing
- `xcodebuild test -scheme Sum -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*