### PR TITLE
Fix cross-actor deinit cleanup

### DIFF
--- a/Sum/ViewModels/ScannerViewModel.swift
+++ b/Sum/ViewModels/ScannerViewModel.swift
@@ -541,7 +541,7 @@ final class ScannerViewModel: ObservableObject {
         NotificationCenter.default.removeObserver(self)
         Task { @MainActor in
             AppStateManager.shared.cancelAllTasks()
+            Self.croppedCache.removeAllObjects()
         }
-        Self.croppedCache.removeAllObjects()
     }
 }


### PR DESCRIPTION
## Summary
- clear the cropped image cache on the main actor in `ScannerViewModel.deinit`

## Testing
- `xcodebuild` *(fails: command not found)*