### PR TITLE
Fix cross-actor deinit cleanup

### DIFF
--- a/Sum/ContentView.swift
+++ b/Sum/ContentView.swift
@@ -255,6 +255,12 @@ struct ContentView: View {
                             LiveOverlayView(numbers: scanVM.liveNumbers)
                                 .allowsHitTesting(false)
                         )
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Done") { navVM.isShowingLiveScanner = false }
+                            }
+                        }
+                        .navigationBarTitleDisplayMode(.inline)
                     }
                 } else {
                     Text("Live OCR requires iOS 17 or later.")

--- a/Sum/ViewModels/ScannerViewModel.swift
+++ b/Sum/ViewModels/ScannerViewModel.swift
@@ -541,7 +541,7 @@ final class ScannerViewModel: ObservableObject {
         NotificationCenter.default.removeObserver(self)
         Task { @MainActor in
             AppStateManager.shared.cancelAllTasks()
+            Self.croppedCache.removeAllObjects()
         }
-        Self.croppedCache.removeAllObjects()
     }
 }


### PR DESCRIPTION
## Summary
- clear the cropped image cache on the main actor in `ScannerViewModel.deinit`
- add a Done button to exit Live OCR

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `xcodebuild test -scheme Sum -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*