### PR TITLE
Improve live OCR highlighting

### DIFF
--- a/Sum/ContentView.swift
+++ b/Sum/ContentView.swift
@@ -230,7 +230,7 @@ struct ContentView: View {
                             },
                             highlights: $liveHighlights,
                             highlightConfs: $liveConfs,
-                            cropRect: $liveCrop,
+                            activeCropRect: $liveCrop,
                             onFixTap: { fix in
                                 scanVM.currentFix = fix
                             },
@@ -242,6 +242,9 @@ struct ContentView: View {
                         .onAppear {
                             print("LiveScanner view appeared")
                         }
+                        .overlay(
+                            LiveCropOverlay(crop: $liveCrop)
+                        )
                         .overlay(
                             LiveHighlightOverlay(
                                 rects: liveHighlights,

--- a/Sum/UI/LiveScannerView.swift
+++ b/Sum/UI/LiveScannerView.swift
@@ -10,7 +10,8 @@ struct LiveScannerView: UIViewControllerRepresentable {
     var onNumbersUpdate: @MainActor ([Double]) -> Void
     @Binding var highlights: [CGRect]
     @Binding var highlightConfs: [Float]
-    @Binding var cropRect: CGRect?
+    /// Crop region in unit space (0…1) updated from SwiftUI
+    @Binding var activeCropRect: CGRect?
     var onFixTap: @MainActor (FixCandidate) -> Void = { _ in }
     var onCoordinatorReady: (Coordinator) -> Void = { _ in }
 
@@ -52,6 +53,10 @@ struct LiveScannerView: UIViewControllerRepresentable {
         if context.coordinator.system != numberSystem {
             context.coordinator.system = numberSystem
         }
+        // Propagate crop rectangle changes
+        if context.coordinator.activeCropRect != activeCropRect {
+            context.coordinator.activeCropRect = activeCropRect
+        }
     }
 
     @MainActor
@@ -59,12 +64,16 @@ struct LiveScannerView: UIViewControllerRepresentable {
         let parent: LiveScannerView
         private var lastSet: Set<Double> = []
         var system: NumberSystem
-        var cropRect: CGRect? = nil
+        var activeCropRect: CGRect? = nil
         private let highlights: Binding<[CGRect]>
         private let highlightConfs: Binding<[Float]>
         private let onFixTap: (FixCandidate) -> Void
         weak var scannerVC: DataScannerViewController?
         private var tapFixes: [(rect: CGRect, value: Double, conf: Float)] = []
+
+        // Track detection stability across frames
+        private var valueCounts: [Double: Int] = [:]
+        private var valueData: [Double: (pixel: CGRect, unit: CGRect, conf: Float)] = [:]
 
         private var lastProcessedTime: CFTimeInterval = 0
         private let frameInterval: CFTimeInterval = 1.0 / 30.0
@@ -99,11 +108,17 @@ struct LiveScannerView: UIViewControllerRepresentable {
             lastProcessedTime = now
 
             tapFixes.removeAll()
-            var current = Set<Double>()
-            var rects = [CGRect]()      // unit-space rects for highlight overlay
-            var confs = [Float]()       // matching confidences
+            var currentFrame: [(value: Double, pixel: CGRect, unit: CGRect, conf: Float)] = []
 
             let hostSize = scanner.view?.bounds.size ?? .zero
+
+            // Convert crop rect from unit space to pixel space for filtering
+            let cropPixelRect: CGRect? = activeCropRect.map { r in
+                CGRect(x: r.minX * hostSize.width,
+                       y: r.minY * hostSize.height,
+                       width: r.width * hostSize.width,
+                       height: r.height * hostSize.height)
+            }
 
             for item in items {
                 if case let .text(textItem) = item {
@@ -132,6 +147,10 @@ struct LiveScannerView: UIViewControllerRepresentable {
 
                         pixelRect = pixelRect.insetBy(dx: -20, dy: -20).integral
 
+                        if let cropPx = cropPixelRect, !pixelRect.intersects(cropPx) {
+                            continue
+                        }
+
                         // Convert to unit space for the overlay
                         let unitRect = CGRect(
                             x: pixelRect.minX / hostSize.width,
@@ -140,17 +159,48 @@ struct LiveScannerView: UIViewControllerRepresentable {
                             height: pixelRect.height / hostSize.height
                         )
 
-                        current.insert(value)
-                        rects.append(unitRect)
-                        confs.append(0.9)
-                        tapFixes.append((rect: pixelRect, value: value, conf: 0.9))
+                        currentFrame.append((value: value,
+                                             pixel: pixelRect,
+                                             unit: unitRect,
+                                             conf: 0.9))
                     }
                 }
             }
 
-            if current != lastSet {
-                lastSet = current
-                let nums = Array(current).sorted()
+            // Update detection stability maps
+            let currentValues = Set(currentFrame.map { $0.value })
+            for val in currentValues {
+                valueCounts[val, default: 0] += 1
+            }
+            for key in Array(valueCounts.keys) {
+                if !currentValues.contains(key) {
+                    valueCounts[key] = max((valueCounts[key] ?? 0) - 1, 0)
+                }
+            }
+            for (val, count) in valueCounts where count == 0 {
+                valueCounts.removeValue(forKey: val)
+                valueData.removeValue(forKey: val)
+            }
+            for data in currentFrame {
+                valueData[data.value] = (pixel: data.pixel, unit: data.unit, conf: data.conf)
+            }
+
+            let stableValues = valueCounts.filter { $0.value >= 2 }.map { $0.key }
+            var rects = [CGRect]()
+            var confs = [Float]()
+            tapFixes.removeAll()
+            for val in stableValues {
+                if let data = valueData[val] {
+                    rects.append(data.unit)
+                    confs.append(data.conf)
+                    tapFixes.append((rect: data.pixel, value: val, conf: data.conf))
+                }
+            }
+
+            let stableSet = Set(stableValues)
+            if stableSet != lastSet {
+                lastSet = stableSet
+                let nums = stableValues.sorted()
 
                 Task { @MainActor in
                     withAnimation(.easeInOut(duration: 0.15)) {


### PR DESCRIPTION
## Summary
- add crop overlay for live OCR session
- refine `LiveScannerView` to track values across frames and support cropping
- forward crop rect changes from SwiftUI host
- rename cropping binding to `activeCropRect`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*